### PR TITLE
Find gcov prefixed with compiler target triplet and env variable hint

### DIFF
--- a/cmake/FindGcov.cmake
+++ b/cmake/FindGcov.cmake
@@ -32,8 +32,15 @@ foreach (LANG ${ENABLED_LANGUAGES})
 			string(REGEX MATCH "^[0-9]+" GCC_VERSION
 				"${CMAKE_${LANG}_COMPILER_VERSION}")
 
-			find_program(GCOV_BIN NAMES gcov-${GCC_VERSION} gcov
-				HINTS ${COMPILER_PATH})
+			find_program(GCOV_BIN
+				NAMES
+					${CMAKE_${LANG}_COMPILER_TARGET}-gcov
+					gcov-${GCC_VERSION}
+					gcov
+				HINTS
+					${COMPILER_PATH}
+					ENV GCOV
+				)
 
 		elseif ("${CMAKE_${LANG}_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
 			# Some distributions like Debian ship llvm-cov with the compiler


### PR DESCRIPTION
We are using OpenEmbedded (OE) to build an SDK for cross-compiling our software for a specific target device. We use qemu to run unit tests on the SDK build machine. The OE SDK includes gcov, which is built against the proper cross-compilation GNU toolchain.

This change adds support for finding the appropriate gcov binary when using SDKs, such as the Yocto/OE SDK using the GNU target triplet, or an environment variable `GCOV`. You can export `GCOV` by using the SDK's environment source script or defining it in a Conan `runenv_info`.